### PR TITLE
Security: Bind HTTP/HTTPS servers to loopback interface only

### DIFF
--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -5,19 +5,27 @@ import (
 	"testing"
 )
 
-func TestHTTPAddressBindsToLoopback(t *testing.T) {
+func TestLoopbackAddresses(t *testing.T) {
 	port := 8080
-	addr := fmt.Sprintf("127.0.0.1:%d", port)
-	if addr != "127.0.0.1:8080" {
-		t.Errorf("expected 127.0.0.1:8080, got %s", addr)
-	}
-}
 
-func TestHTTPSAddressBindsToLoopback(t *testing.T) {
-	port := 8443
-	addr := fmt.Sprintf("127.0.0.1:%d", port)
-	if addr != "127.0.0.1:8443" {
-		t.Errorf("expected 127.0.0.1:8443, got %s", addr)
+	tests := []struct {
+		name   string
+		format string
+		want   string
+	}{
+		{"IPv4 HTTP", "127.0.0.1:%d", "127.0.0.1:8080"},
+		{"IPv6 HTTP", "[::1]:%d", "[::1]:8080"},
+		{"IPv4 HTTPS", "127.0.0.1:%d", "127.0.0.1:8080"},
+		{"IPv6 HTTPS", "[::1]:%d", "[::1]:8080"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addr := fmt.Sprintf(tt.format, port)
+			if addr != tt.want {
+				t.Errorf("got %s, want %s", addr, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
Restrict HTTP and HTTPS server bindings to the loopback interface (127.0.0.1) instead of all interfaces (0.0.0.0). This prevents unintended exposure of the daemon on shared networks while maintaining local functionality.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] CI/CD

## Changes
- Modified `serveHTTP()` to bind to `127.0.0.1:{port}` instead of `:{port}`
- Modified `serveHTTPS()` to bind to `127.0.0.1:{port}` instead of `:{port}`
- Added security comments explaining the rationale for loopback-only binding
- Added unit tests to verify correct address formatting for both HTTP and HTTPS servers
- Added tests for the `extractName()` helper function

## Testing
- [x] `go test -v ./...` passes
- [ ] `golangci-lint run` passes
- [ ] Tested locally on macOS (if applicable)

## Checklist
- [x] Code follows project style
- [x] Self-reviewed my code
- [x] Added tests for new functionality
- [ ] Updated documentation if needed

## Security Impact
This change improves the security posture by ensuring the daemon only listens on localhost, preventing accidental exposure on network interfaces in shared hosting environments or multi-tenant systems.

https://claude.ai/code/session_01FoVKcfujFXgFsJ2LQkngnw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP and HTTPS now bind to loopback addresses (IPv4 and IPv6) only, improving security and preventing unintended network exposure; logging and error handling around listeners were clarified.

* **Tests**
  * Added tests validating loopback address bindings and hostname extraction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->