### PR TITLE
fix: bind HTTP/HTTPS servers to loopback only

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -127,7 +127,8 @@ func (d *Daemon) cleanupRoutine() {
 }
 
 func (d *Daemon) serveHTTP() {
-	addr := fmt.Sprintf(":%d", d.config.HTTPPort)
+	// SECURITY: Bind to loopback only — prevent LAN exposure of dev servers
+	addr := fmt.Sprintf("127.0.0.1:%d", d.config.HTTPPort)
 	log.Printf("HTTP redirect server listening on %s", addr)
 
 	server := &http.Server{
@@ -144,7 +145,8 @@ func (d *Daemon) serveHTTP() {
 }
 
 func (d *Daemon) serveHTTPS() error {
-	addr := fmt.Sprintf(":%d", d.config.HTTPSPort)
+	// SECURITY: Bind to loopback only — prevent LAN exposure of dev servers
+	addr := fmt.Sprintf("127.0.0.1:%d", d.config.HTTPSPort)
 	log.Printf("HTTPS server listening on %s", addr)
 
 	// SECURITY: TLS hardening - minimum TLS 1.2, secure cipher suites


### PR DESCRIPTION
## Summary
- Binds HTTP redirect server and HTTPS server to `127.0.0.1` instead of `0.0.0.0`
- Prevents LAN exposure of dev servers on shared networks (cafes, coworking)
- Matches existing DNS server behavior which already binds to loopback

Fixes #40

## Test plan
- [x] `go test -v -race ./...` passes
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Server now binds exclusively to the loopback address, restricting connections to local machine access only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->