### PR TITLE
fix: preserve original Host header in proxy

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -56,7 +56,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request, upstream strin
 	outReq := r.Clone(r.Context())
 	outReq.URL.Scheme = "http"
 	outReq.URL.Host = upstream
-	outReq.Host = upstream
+	// Preserve original Host header for upstream virtual hosting (URL.Host is used for dialing)
 	outReq.RequestURI = ""
 
 	// Set forwarding headers


### PR DESCRIPTION
## Summary
- Removes `outReq.Host = upstream` so the original Host header (e.g. `myapp.test`) is forwarded
- `URL.Host` still controls TCP dialing to the upstream address
- Fixes virtual hosting, CORS validation, and OAuth callbacks in upstream dev servers

Fixes #41

## Test plan
- [x] Added `TestProxy_PreservesHostHeader` to verify Host header preservation
- [x] `go test -v -race ./...` passes
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the proxy's request forwarding to preserve the original Host header when proxying to upstream servers, enabling correct virtual hosting behavior.

* **Tests**
  * Added comprehensive test to verify that the Host header is properly preserved during proxy request forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->