### PR TITLE
fix: use 308 redirect to preserve HTTP method

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -133,11 +133,8 @@ func (d *Daemon) serveHTTP() {
 	server := &http.Server{
 		Addr: addr,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			target := "https://" + r.Host + r.URL.Path
-			if r.URL.RawQuery != "" {
-				target += "?" + r.URL.RawQuery
-			}
-			http.Redirect(w, r, target, http.StatusMovedPermanently)
+			target := "https://" + r.Host + r.URL.RequestURI()
+			http.Redirect(w, r, target, http.StatusPermanentRedirect)
 		}),
 	}
 	server.ListenAndServe()


### PR DESCRIPTION
## Summary
- Changes HTTP→HTTPS redirect from 301 to 308 (Permanent Redirect)
- 308 preserves the original HTTP method (POST stays POST)
- Uses `r.URL.RequestURI()` to correctly handle percent-encoded paths

Fixes #48

## Test plan
- [x] `go test -v -race ./...` passes
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP redirect handling to properly preserve query parameters and use the appropriate status code for permanent redirects, ensuring more reliable redirect behavior across all request types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->