### PR TITLE
fix: set CA MaxPathLen to 0

### DIFF
--- a/internal/ssl/ca.go
+++ b/internal/ssl/ca.go
@@ -41,7 +41,9 @@ func GenerateCA(certPath, keyPath string) error {
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
 		IsCA:                  true,
-		MaxPathLen:            1,
+		// SECURITY: MaxPathLen 0 prevents signing intermediate CAs
+		MaxPathLen:     0,
+		MaxPathLenZero: true,
 	}
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, priv.Public(), priv)

--- a/internal/ssl/ca_test.go
+++ b/internal/ssl/ca_test.go
@@ -37,4 +37,10 @@ func TestGenerateCA(t *testing.T) {
 	if ca.Leaf.Subject.CommonName != "paw-proxy CA" {
 		t.Errorf("unexpected CN: %s", ca.Leaf.Subject.CommonName)
 	}
+	if ca.Leaf.MaxPathLen != 0 {
+		t.Errorf("expected MaxPathLen 0, got %d", ca.Leaf.MaxPathLen)
+	}
+	if !ca.Leaf.MaxPathLenZero {
+		t.Error("MaxPathLenZero should be true")
+	}
 }


### PR DESCRIPTION
## Summary
- Sets `MaxPathLen: 0` and `MaxPathLenZero: true` on the CA certificate
- Prevents creation of intermediate CAs if the CA key is compromised
- Added test assertions for MaxPathLen constraints

Fixes #49

## Test plan
- [x] Added MaxPathLen assertions to `TestGenerateCA`
- [x] `go test -v -race ./...` passes
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)