### PR TITLE
fix: update CI Go version to 1.24 to match go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.24'
       - uses: golangci/golangci-lint-action@v4
 
   test:
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.24'
       - run: go test -v -race ./...
 
   build:
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.24'
       - run: |
           GOOS=darwin GOARCH=arm64 go build -o paw-proxy-arm64 ./cmd/paw-proxy
           GOOS=darwin GOARCH=amd64 go build -o paw-proxy-amd64 ./cmd/paw-proxy
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.24'
       - name: Build
         run: |
           go build -o paw-proxy ./cmd/paw-proxy


### PR DESCRIPTION
## Summary
- Updates `go-version` from `1.22` to `1.24` in all 4 CI jobs
- Matches `go.mod` declaration (`go 1.24.0`) and `miekg/dns` requirement

Fixes #34

## Test plan
- [x] `go test -v -race ./...` passes
- [x] `go vet ./...` clean
- [ ] CI pipeline will validate on this PR itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)