### PR TITLE
fix: use explicit permissions for CA cert file

### DIFF
--- a/internal/ssl/ca.go
+++ b/internal/ssl/ca.go
@@ -49,8 +49,8 @@ func GenerateCA(certPath, keyPath string) error {
 		return fmt.Errorf("creating certificate: %w", err)
 	}
 
-	// Write cert
-	certOut, err := os.Create(certPath)
+	// Write cert with explicit permissions (not secret, but consistent with project conventions)
+	certOut, err := os.OpenFile(certPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return fmt.Errorf("creating cert file: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Replaces `os.Create` with `os.OpenFile(..., 0644)` for the CA cert file
- Matches the project convention of explicit file permissions (key=0600, socket=0600, dir=0700)

Fixes #35

## Test plan
- [x] `go test -v -race ./...` passes
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)