### PR TITLE
fix: bind HTTP/HTTPS servers to loopback only

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -127,7 +127,8 @@ func (d *Daemon) cleanupRoutine() {
 }
 
 func (d *Daemon) serveHTTP() {
-	addr := fmt.Sprintf(":%d", d.config.HTTPPort)
+	// SECURITY: Bind to loopback only, not all interfaces
+	addr := fmt.Sprintf("127.0.0.1:%d", d.config.HTTPPort)
 	log.Printf("HTTP redirect server listening on %s", addr)
 
 	server := &http.Server{
@@ -141,7 +142,8 @@ func (d *Daemon) serveHTTP() {
 }
 
 func (d *Daemon) serveHTTPS() error {
-	addr := fmt.Sprintf(":%d", d.config.HTTPSPort)
+	// SECURITY: Bind to loopback only, not all interfaces
+	addr := fmt.Sprintf("127.0.0.1:%d", d.config.HTTPSPort)
 	log.Printf("HTTPS server listening on %s", addr)
 
 	// SECURITY: TLS hardening - minimum TLS 1.2, secure cipher suites


### PR DESCRIPTION
## Summary
Fixes #40 - Security fix to prevent local network access to the dev proxy

## Changes
- HTTP redirect server (port 80) now binds to `127.0.0.1` instead of `0.0.0.0`
- HTTPS proxy server (port 443) now binds to `127.0.0.1` instead of `0.0.0.0`
- Added SECURITY comments explaining the binding choice

## Security Impact
**Before:** Any device on the local network could access registered routes and dev servers through the proxy (risky on shared WiFi networks like cafes, coworking spaces, conferences).

**After:** Only processes on the local machine can access the proxy.

## Test Plan
- [x] All existing tests pass (`go test -v -race ./...`)
- [x] `go vet ./...` passes with no issues
- [x] Changes verified with `git diff`

🤖 Generated with [Claude Code](https://claude.com/claude-code)