### PR TITLE
fix: wait for both WebSocket goroutines to prevent leak

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -137,4 +137,5 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request, upstream
 	}()
 
 	<-done
+	<-done // Wait for both goroutines to complete
 }


### PR DESCRIPTION
## Summary
- Fixes #4 - WebSocket goroutine leak
- Added second `<-done` read to wait for both bidirectional copy goroutines

## Problem
The WebSocket handler spawned two goroutines for bidirectional copying (client→upstream and upstream→client) but only waited for one to complete. Whichever goroutine finished first would unblock the handler, leaving the other orphaned.

## Impact
- Each WebSocket connection leaked one goroutine
- Leaked goroutines persisted until the 1-hour deadline
- Development servers with hot-reload (Vite, Next.js) establish frequent WebSocket connections
- Over a typical dev session, hundreds of leaked goroutines would accumulate

## Solution
Added a second `<-done` read on line 140. The buffered channel (size 2) already prevents deadlock, so this simply ensures both goroutines signal completion before the function returns.

## Testing
- ✅ All existing tests pass with `-race` flag
- ✅ `go vet` clean
- Fix is a one-line change to critical synchronization logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)