### PR TITLE
fix: sanitizeName now lowercases and trims dashes

### DIFF
--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -177,17 +178,29 @@ func determineName(explicit string) string {
 }
 
 func sanitizeName(name string) string {
+	// Import strings package at top if not already imported
+	name = strings.ToLower(name)
+
 	// Replace non-alphanumeric with dashes
 	result := make([]byte, 0, len(name))
 	for i := 0; i < len(name); i++ {
 		c := name[i]
-		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' {
+		if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-' {
 			result = append(result, c)
 		} else {
 			result = append(result, '-')
 		}
 	}
-	return string(result)
+
+	// Trim leading and trailing dashes
+	sanitized := strings.Trim(string(result), "-")
+
+	// Fallback to "app" if empty
+	if sanitized == "" {
+		return "app"
+	}
+
+	return sanitized
 }
 
 func socketClient(socketPath string) *http.Client {

--- a/cmd/up/main_test.go
+++ b/cmd/up/main_test.go
@@ -1,0 +1,74 @@
+// cmd/up/main_test.go
+package main
+
+import (
+	"testing"
+)
+
+func TestSanitizeName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "converts to lowercase",
+			input:    "MyApp",
+			expected: "myapp",
+		},
+		{
+			name:     "replaces special characters with dashes",
+			input:    "my@app",
+			expected: "my-app",
+		},
+		{
+			name:     "trims leading dashes",
+			input:    "@scope/pkg",
+			expected: "scope-pkg",
+		},
+		{
+			name:     "trims trailing dashes",
+			input:    "app@@@",
+			expected: "app",
+		},
+		{
+			name:     "handles multiple consecutive special chars",
+			input:    "my@@app",
+			expected: "my--app",
+		},
+		{
+			name:     "preserves existing dashes",
+			input:    "my-app",
+			expected: "my-app",
+		},
+		{
+			name:     "handles all special characters",
+			input:    "@@@",
+			expected: "app",
+		},
+		{
+			name:     "handles scoped package names",
+			input:    "@babel/core",
+			expected: "babel-core",
+		},
+		{
+			name:     "handles mixed case with special chars",
+			input:    "MyApp@2.0",
+			expected: "myapp-2-0",
+		},
+		{
+			name:     "handles empty string",
+			input:    "",
+			expected: "app",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeName(tt.input)
+			if got != tt.expected {
+				t.Errorf("sanitizeName(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Fixes #45 - `sanitizeName()` in `cmd/up/main.go` now properly handles edge cases

## Changes
Three bugs fixed:

1. **No lowercasing** - `"MyApp"` stayed `"MyApp"` instead of `"myapp"`
   - DNS is case-insensitive but route names should be consistent
   - Added `strings.ToLower()` before processing

2. **Leading/trailing dashes** - `"@scope/pkg"` became `"-scope-pkg"`
   - Violated daemon's `routeNamePattern` requiring alphanumeric first char
   - Added `strings.Trim(result, "-")` to strip leading/trailing dashes

3. **All-special-chars** - `"@@@"` became `"---"`, empty string stayed `""`
   - Both failed validation at registration
   - Added fallback: if `sanitized == ""` return `"app"`

## Test Coverage
- Created `cmd/up/main_test.go` with 10 table-driven test cases
- TDD approach: wrote failing tests first, then implemented fix
- All tests pass with `-race` flag
- `go vet ./...` clean

## Test Cases
✅ Converts to lowercase: `"MyApp"` → `"myapp"`  
✅ Trims leading dashes: `"@scope/pkg"` → `"scope-pkg"`  
✅ Trims trailing dashes: `"app@@@"` → `"app"`  
✅ Fallback for all-special: `"@@@"` → `"app"`  
✅ Fallback for empty: `""` → `"app"`  
✅ Handles scoped packages: `"@babel/core"` → `"babel-core"`  
✅ Preserves existing dashes: `"my-app"` → `"my-app"`  

🤖 Generated with [Claude Code](https://claude.com/claude-code)