### PR TITLE
fix: return error for empty SNI in certificate generation

### DIFF
--- a/internal/ssl/cert.go
+++ b/internal/ssl/cert.go
@@ -34,6 +34,9 @@ func NewCertCache(ca *tls.Certificate) *CertCache {
 
 func (c *CertCache) GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 	name := hello.ServerName
+	if name == "" {
+		return nil, fmt.Errorf("SNI required: connect using hostname, not IP")
+	}
 
 	c.mu.RLock()
 	if cert, ok := c.cache[name]; ok {


### PR DESCRIPTION
## Summary
Fixes #50 by adding validation to reject TLS connections without SNI (Server Name Indication).

## Problem
Previously, `GetCertificate()` would generate certificates with empty `CommonName` and `DNSNames: [""]` when clients connected without SNI (e.g., using `https://127.0.0.1/`). These invalid certificates wouldn't validate in any browser.

## Changes
- Added validation check on line 37 to return error if `ServerName` is empty
- Error message: "SNI required: connect using hostname, not IP"

## Testing
- ✅ All unit tests pass (`go test -v -race ./...`)
- ✅ Static analysis clean (`go vet ./...`)
- ✅ Existing test `TestCertCache_GeneratesCertForDomain` validates normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented Server Name Indication (SNI) validation for SSL certificate requests. Connections must now use valid hostnames instead of IP addresses to ensure proper certificate resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->