### PR TITLE
fix: disable WriteTimeout to support SSE connections

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -166,9 +166,11 @@ func (d *Daemon) serveHTTPS() error {
 	}
 
 	server := &http.Server{
-		Handler:      http.HandlerFunc(d.handleRequest),
-		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 60 * time.Second,
+		Handler:     http.HandlerFunc(d.handleRequest),
+		ReadTimeout: 30 * time.Second,
+		// WriteTimeout disabled (0) to support SSE connections (Vite HMR, Next.js Fast Refresh, etc.)
+		// SSE keeps connections open indefinitely, and a fixed timeout breaks hot reload.
+		WriteTimeout: 0,
 		IdleTimeout:  120 * time.Second,
 	}
 


### PR DESCRIPTION
## Summary
Fixes #24 - SSE connections (Vite HMR, Next.js Fast Refresh) now work indefinitely instead of breaking after 60 seconds

## Problem
The HTTPS server had `WriteTimeout: 60 * time.Second`, which limits the *total time* for writing a response. Server-Sent Events (SSE) keep connections open and stream small chunks indefinitely, so they were killed after exactly 60 seconds.

This caused:
- Vite HMR to stop working after 1 minute
- Next.js Fast Refresh to fail silently
- Confusing user experience (hot reload "just stops working")

## Changes
- Set `WriteTimeout: 0` (disabled) in the HTTPS server configuration
- Added explanatory comment about SSE and why timeout is disabled
- `IdleTimeout: 120s` still protects against truly dead connections
- `ReadTimeout: 30s` still prevents slow clients from tying up resources

## Why This Approach
For a development proxy where SSE is common (HMR, Fast Refresh, live reload), disabling WriteTimeout entirely is the simplest and most reliable fix. The other timeouts still provide protection against misbehaving clients.

Alternative approaches considered:
- Using `http.ResponseController` to extend deadline per-request (more complex, requires detecting SSE)
- Increasing timeout to a large value (doesn't solve the root problem)

## Test Plan
- [x] All existing tests pass (`go test -v -race ./...`)
- [x] `go vet ./...` passes with no issues
- [x] Changes verified with `git diff`

🤖 Generated with [Claude Code](https://claude.com/claude-code)