### PR TITLE
fix: daemon lifecycle overhaul

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
     branches: [main]
 
+  # Enable re-triggering from auto-update-pr.yml workflow.
+  # When a PR branch is updated using GITHUB_TOKEN, GitHub suppresses the
+  # usual pull_request:synchronize event — so CI doesn't run automatically.
+  # However, workflow_dispatch IS exempt from this suppression.
+  workflow_dispatch:
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -58,11 +64,28 @@ jobs:
       - name: Prepare for daemon
         run: |
           sudo chmod 755 "$HOME/Library/Application Support/paw-proxy"
+          # Unload with sudo since setup loaded it in the root launchd domain
+          sudo launchctl unload ~/Library/LaunchAgents/dev.paw-proxy.plist 2>/dev/null || true
           launchctl unload ~/Library/LaunchAgents/dev.paw-proxy.plist 2>/dev/null || true
       - name: Start daemon
         run: |
           sudo ./paw-proxy run &
-          sleep 2
+          DAEMON_PID=$!
+          echo "DAEMON_PID=$DAEMON_PID" >> "$GITHUB_ENV"
+          # Wait for socket to appear (daemon logs to stderr now via MultiWriter)
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            if [ -S "$HOME/Library/Application Support/paw-proxy/paw-proxy.sock" ]; then
+              echo "Socket appeared after ${i}s"
+              break
+            fi
+            # Check daemon is still running
+            if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
+              echo "::error::Daemon process exited prematurely"
+              cat "$HOME/Library/Logs/paw-proxy.log" 2>/dev/null || true
+              exit 1
+            fi
+            sleep 1
+          done
           sudo chmod 777 "$HOME/Library/Application Support/paw-proxy/paw-proxy.sock"
       - name: Wait for daemon
         run: |
@@ -75,3 +98,8 @@ jobs:
           done
       - name: Integration Tests
         run: ./integration-tests.sh
+      - name: Dump daemon logs on failure
+        if: failure()
+        run: |
+          echo "=== Daemon log ==="
+          cat "$HOME/Library/Logs/paw-proxy.log" 2>/dev/null || echo "No log file found"

--- a/cmd/paw-proxy/main.go
+++ b/cmd/paw-proxy/main.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -68,7 +69,9 @@ func cmdRun() {
 		log.Fatalf("Failed to open log file: %v", err)
 	}
 	defer logFile.Close()
-	log.SetOutput(logFile)
+	// Write to both log file and stderr so startup failures are visible
+	// when the daemon is run directly (e.g., CI, debugging).
+	log.SetOutput(io.MultiWriter(logFile, os.Stderr))
 
 	d, err := daemon.New(config)
 	if err != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -152,6 +152,8 @@ func (d *Daemon) Run() error {
 	httpServer, httpListener, err := d.createHTTPServer()
 	if err != nil {
 		cancel()
+		d.dnsServer.Stop()
+		d.apiServer.Stop()
 		return fmt.Errorf("creating HTTP server: %w", err)
 	}
 	wg.Add(1)
@@ -167,6 +169,9 @@ func (d *Daemon) Run() error {
 	httpsServer, httpsListener, err := d.createHTTPSServer()
 	if err != nil {
 		cancel()
+		httpListener.Close()
+		d.dnsServer.Stop()
+		d.apiServer.Stop()
 		return fmt.Errorf("creating HTTPS server: %w", err)
 	}
 	wg.Add(1)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -91,23 +91,4 @@ func TestHTTPRedirectPreservesFullURL(t *testing.T) {
 	}
 }
 
-func TestExtractName(t *testing.T) {
-	tests := []struct {
-		host     string
-		expected string
-	}{
-		{"myapp.test", "myapp"},
-		{"myapp.test:443", "myapp"},
-		{"dashboard.test", "dashboard"},
-		{"simple", "simple"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.host, func(t *testing.T) {
-			got := extractName(tt.host)
-			if got != tt.expected {
-				t.Errorf("extractName(%q) = %q, want %q", tt.host, got, tt.expected)
-			}
-		})
-	}
-}
+// TestExtractName moved to api package — ExtractName is now api.ExtractName


### PR DESCRIPTION
## Summary
- Rewrites daemon.Run() with proper signal handling (SIGTERM/SIGINT), WaitGroup coordination, and graceful shutdown
- Component failures now crash the daemon instead of being silently logged
- HTTP/HTTPS servers bind to 127.0.0.1 instead of 0.0.0.0
- Removes Read/WriteTimeout to fix SSE (Vite HMR) and large file transfers
- HTTP→HTTPS redirect uses 308 (preserves method) + RequestURI (preserves query/path)
- Warns at startup if CA certificate expires within 30 days
- Cleanup ticker properly stops on shutdown
- Socket file removed on shutdown

Closes #3, closes #6, closes #40, closes #24, closes #25, closes #48, closes #14

## Test plan
- [ ] `go test -v -race ./...` passes
- [ ] `go vet ./...` clean
- [ ] CI integration tests pass on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored daemon architecture to improve service stability, enable graceful shutdown with proper signal handling, and ensure cleaner resource cleanup.

* **Tests**
  * Expanded test coverage with validations for HTTP redirect behavior, URL preservation, and hostname extraction across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->