### PR TITLE
fix: uninstall error handling and shell safety

### DIFF
--- a/internal/setup/uninstall_darwin.go
+++ b/internal/setup/uninstall_darwin.go
@@ -13,23 +13,39 @@ import (
 )
 
 func Uninstall(supportDir, tld string, fromBrew bool) error {
-	homeDir, _ := os.UserHomeDir()
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("getting home directory: %w", err)
+	}
 	plistPath := filepath.Join(homeDir, "Library", "LaunchAgents", "dev.paw-proxy.plist")
 	resolverPath := filepath.Join("/etc/resolver", tld)
+
+	var errs []string
 
 	fmt.Println("paw-proxy uninstall")
 	fmt.Println("===================")
 
 	// 1. Stop and remove LaunchAgent
 	fmt.Printf("\n[1/3] Removing daemon...\n")
-	exec.Command("launchctl", "unload", plistPath).Run()
-	os.Remove(plistPath)
-	fmt.Printf("  ✓ LaunchAgent removed\n")
+	if err := exec.Command("launchctl", "unload", plistPath).Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: could not unload LaunchAgent: %v\n", err)
+		// Not fatal — agent may not be loaded
+	}
+	if err := os.Remove(plistPath); err != nil && !os.IsNotExist(err) {
+		errs = append(errs, fmt.Sprintf("removing LaunchAgent plist: %v", err))
+		fmt.Fprintf(os.Stderr, "  warning: could not remove plist: %v\n", err)
+	} else {
+		fmt.Printf("  LaunchAgent removed\n")
+	}
 
 	// 2. Remove resolver
 	fmt.Printf("\n[2/3] Removing DNS resolver...\n")
-	os.Remove(resolverPath)
-	fmt.Printf("  ✓ /etc/resolver/%s removed\n", tld)
+	if err := os.Remove(resolverPath); err != nil && !os.IsNotExist(err) {
+		errs = append(errs, fmt.Sprintf("removing resolver file: %v", err))
+		fmt.Fprintf(os.Stderr, "  warning: could not remove /etc/resolver/%s: %v\n", tld, err)
+	} else {
+		fmt.Printf("  /etc/resolver/%s removed\n", tld)
+	}
 
 	// 3. Remove CA (prompt unless --brew)
 	removeCA := fromBrew
@@ -41,24 +57,48 @@ func Uninstall(supportDir, tld string, fromBrew bool) error {
 	}
 
 	if removeCA {
-		// Remove from keychain
-		cmd := exec.Command("sh", "-c", `
-			for sha in $(security find-certificate -a -c "paw-proxy CA" -Z | awk '/SHA-1/ {print $3}'); do
-				security delete-certificate -Z $sha 2>/dev/null || true
-			done
-		`)
-		cmd.Run()
-		fmt.Printf("  ✓ CA removed from keychain\n")
+		// SECURITY: Use explicit exec.Command args instead of sh -c to prevent shell injection
+		keychainPath := filepath.Join(homeDir, "Library", "Keychains", "login.keychain-db")
+		out, err := exec.Command("security", "find-certificate", "-a", "-c", "paw-proxy CA", "-Z", keychainPath).Output()
+		if err != nil {
+			// No certs found is not an error — may have been removed already
+			fmt.Println("  No CA certificates found in keychain")
+		} else {
+			// Parse SHA-1 hashes from output
+			for _, line := range strings.Split(string(out), "\n") {
+				line = strings.TrimSpace(line)
+				if strings.HasPrefix(line, "SHA-1 hash:") {
+					sha := strings.TrimSpace(strings.TrimPrefix(line, "SHA-1 hash:"))
+					if sha != "" {
+						if err := exec.Command("security", "delete-certificate", "-Z", sha, keychainPath).Run(); err != nil {
+							errs = append(errs, fmt.Sprintf("removing cert %s: %v", sha[:8], err))
+							fmt.Fprintf(os.Stderr, "  warning: could not remove certificate %s: %v\n", sha[:8], err)
+						} else {
+							fmt.Printf("  Removed certificate %s\n", sha[:8])
+						}
+					}
+				}
+			}
+		}
 
 		// Remove support directory
-		os.RemoveAll(supportDir)
-		fmt.Printf("  ✓ Support directory removed\n")
+		if err := os.RemoveAll(supportDir); err != nil {
+			errs = append(errs, fmt.Sprintf("removing support directory: %v", err))
+			fmt.Fprintf(os.Stderr, "  warning: could not remove support directory: %v\n", err)
+		} else {
+			fmt.Printf("  Support directory removed\n")
+		}
 	} else {
-		fmt.Printf("  ⏭  CA kept in keychain\n")
+		fmt.Printf("  CA kept in keychain\n")
 	}
 
 	fmt.Println("\n===================")
-	fmt.Println("Uninstall complete!")
 
+	if len(errs) > 0 {
+		fmt.Println("Uninstall completed with errors.")
+		return fmt.Errorf("uninstall completed with errors: %s", strings.Join(errs, "; "))
+	}
+
+	fmt.Println("Uninstall complete!")
 	return nil
 }


### PR DESCRIPTION
## Summary
- Uninstall now reports all errors instead of silently swallowing them (fixes #37)
- Errors are accumulated in a `[]string` slice and returned as a combined error message
- Replaced `sh -c` shell pipeline with pure Go: `exec.Command("security", "find-certificate", ...)` + parse SHA-1 hashes + `exec.Command("security", "delete-certificate", ...)` (fixes #38)
- Each step prints status to stdout and warnings to stderr
- `os.UserHomeDir()` error is now checked instead of ignored
- `os.Remove` / `os.RemoveAll` errors are checked (with `os.IsNotExist` tolerance for already-removed files)

Closes #37, closes #38

## Design decisions
- `launchctl unload` failure is logged as a warning but not accumulated as an error, since the agent may not be loaded (e.g., first install, or already stopped)
- `os.IsNotExist` errors from file removal are tolerated silently -- the file being gone is the desired state
- Keychain path uses `login.keychain-db` which matches the standard macOS login keychain location
- Removed emoji characters from output messages for cleaner terminal output

## Test plan
- [x] `go build ./cmd/paw-proxy/` compiles
- [x] `go vet ./...` clean
- [x] `go test -v -race ./...` all pass
- [ ] CI integration tests pass on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved uninstall process robustness on macOS with better error handling for missing system components.
  * Enhanced error reporting to collect and display all issues encountered during uninstallation.
  * Refined user prompts and completion messages to clearly indicate which components were kept or removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->