### PR TITLE
fix: API security and correctness improvements

### DIFF
--- a/internal/api/routes_test.go
+++ b/internal/api/routes_test.go
@@ -2,6 +2,8 @@
 package api
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 )
@@ -87,4 +89,139 @@ func TestRouteRegistry_Heartbeat(t *testing.T) {
 	if ok {
 		t.Error("expected route to be expired")
 	}
+}
+
+func TestRouteRegistry_LookupReturnsCopy(t *testing.T) {
+	r := NewRouteRegistry(30 * time.Second)
+
+	err := r.Register("myapp", "localhost:3000", "/path")
+	if err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+
+	// Get a copy and mutate it
+	route, ok := r.Lookup("myapp")
+	if !ok {
+		t.Fatal("Lookup failed")
+	}
+	route.Upstream = "mutated:9999"
+
+	// Original should be unchanged
+	original, ok := r.Lookup("myapp")
+	if !ok {
+		t.Fatal("second Lookup failed")
+	}
+	if original.Upstream != "localhost:3000" {
+		t.Errorf("mutation leaked: got upstream %q, want %q", original.Upstream, "localhost:3000")
+	}
+}
+
+func TestRouteRegistry_ListReturnsCopies(t *testing.T) {
+	r := NewRouteRegistry(30 * time.Second)
+
+	err := r.Register("myapp", "localhost:3000", "/path")
+	if err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+
+	routes := r.List()
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(routes))
+	}
+
+	// Mutate the returned copy
+	routes[0].Upstream = "mutated:9999"
+
+	// Original should be unchanged
+	original, ok := r.Lookup("myapp")
+	if !ok {
+		t.Fatal("Lookup failed")
+	}
+	if original.Upstream != "localhost:3000" {
+		t.Errorf("List mutation leaked: got upstream %q, want %q", original.Upstream, "localhost:3000")
+	}
+}
+
+func TestRouteRegistry_ConcurrentAccess(t *testing.T) {
+	r := NewRouteRegistry(100 * time.Millisecond)
+
+	// Pre-register some routes
+	for i := 0; i < 10; i++ {
+		name := fmt.Sprintf("app%d", i)
+		err := r.Register(name, fmt.Sprintf("localhost:%d", 3000+i), "/path")
+		if err != nil {
+			t.Fatalf("Register %s failed: %v", name, err)
+		}
+	}
+
+	var wg sync.WaitGroup
+	done := make(chan struct{})
+
+	// Concurrent Lookups
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			name := fmt.Sprintf("app%d", id%10)
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					r.Lookup(name)
+					r.LookupByHost(name + ".test:443")
+				}
+			}
+		}(i)
+	}
+
+	// Concurrent Heartbeats
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			name := fmt.Sprintf("app%d", id%10)
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					r.Heartbeat(name)
+				}
+			}
+		}(i)
+	}
+
+	// Concurrent List
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				r.List()
+			}
+		}
+	}()
+
+	// Concurrent Cleanup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				r.Cleanup()
+			}
+		}
+	}()
+
+	// Let it run for a bit under -race
+	time.Sleep(200 * time.Millisecond)
+	close(done)
+	wg.Wait()
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -181,18 +181,9 @@ func (d *Daemon) handleRequest(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusBadGateway)
-		fmt.Fprintf(w, "No app registered for %s\n\nRun: up -n %s <your-dev-command>\n", r.Host, extractName(r.Host))
+		fmt.Fprintf(w, "No app registered for %s\n\nRun: up -n %s <your-dev-command>\n", r.Host, api.ExtractName(r.Host))
 		return
 	}
 
 	d.proxy.ServeHTTP(w, r, route.Upstream)
-}
-
-func extractName(host string) string {
-	for i, c := range host {
-		if c == '.' || c == ':' {
-			return host[:i]
-		}
-	}
-	return host
 }


### PR DESCRIPTION
## Summary
- **Socket TOCTOU fix (#47):** Permissions set atomically via `syscall.Umask(0077)` before `net.Listen`, eliminating the race window between Listen and Chmod where another process could connect
- **SSRF IPv6 fix (#46):** Replaced explicit host allowlist with `net.ParseIP` + `IsLoopback()` for robust loopback detection — accepts all 127.0.0.0/8 and ::1, rejects everything else
- **JSON error responses (#53):** Added `jsonError()` helper; all `http.Error()` calls replaced with JSON-formatted responses including `Content-Type: application/json`
- **Route data race fix (#42):** `Lookup`, `LookupByHost`, and `List` now return value copies instead of mutable pointers; `Cleanup` uses read-lock for scanning and write-lock only for deletion
- **Deduplicate ExtractName (#39):** Exported `api.ExtractName()` and removed the duplicate `extractName()` from daemon.go

## Design decisions
- `127.0.0.2` is now accepted as a valid upstream (it IS a loopback address per RFC). Updated test expectations accordingly.
- `Cleanup()` re-checks heartbeat timestamps under write lock to handle the case where a heartbeat arrives between releasing the read lock and acquiring the write lock.

Closes #47, closes #46, closes #53, closes #42, closes #39

## Test plan
- [x] `go test -v -race ./...` passes (all packages)
- [x] `go vet ./...` clean
- [ ] CI integration tests pass on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)