### PR TITLE
test: fill coverage gaps across packages

### DIFF
--- a/internal/dns/server_test.go
+++ b/internal/dns/server_test.go
@@ -44,3 +44,42 @@ func TestDNSServer_ResolvesTestDomain(t *testing.T) {
 		t.Errorf("expected 127.0.0.1, got %v", a.A)
 	}
 }
+
+// TestAAAAQuery sends a DNS AAAA query for "example.test" and verifies
+// it returns ::1 (IPv6 loopback).
+func TestAAAAQuery(t *testing.T) {
+	srv, err := NewServer("127.0.0.1:19354", "test")
+	if err != nil {
+		t.Fatalf("failed to create server: %v", err)
+	}
+	defer srv.Stop()
+
+	go srv.Start()
+
+	// Wait for server to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Send AAAA query
+	c := new(dns.Client)
+	m := new(dns.Msg)
+	m.SetQuestion("example.test.", dns.TypeAAAA)
+
+	r, _, err := c.Exchange(m, "127.0.0.1:19354")
+	if err != nil {
+		t.Fatalf("DNS AAAA query failed: %v", err)
+	}
+
+	if len(r.Answer) == 0 {
+		t.Fatal("expected AAAA answer, got none")
+	}
+
+	aaaa, ok := r.Answer[0].(*dns.AAAA)
+	if !ok {
+		t.Fatalf("expected AAAA record, got %T", r.Answer[0])
+	}
+
+	expected := net.ParseIP("::1")
+	if !aaaa.AAAA.Equal(expected) {
+		t.Errorf("expected ::1, got %v", aaaa.AAAA)
+	}
+}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -429,3 +429,4 @@ func TestWebSocket_BothGoroutinesComplete(t *testing.T) {
 		}
 	}
 }
+


### PR DESCRIPTION
## Summary
- Adds WebSocket bidirectional proxy test with TCP echo server upstream
- Adds WebSocket client disconnect test verifying upstream cleanup
- Adds CertCache concurrent access test (50 goroutines, -race safe)
- Adds CertCache LRU eviction test (fills to maxCacheSize, verifies oldest evicted)
- Adds DNS AAAA (IPv6) query test returning ::1
- Adds RouteRegistry concurrent access test (100 goroutines, -race safe)
- Adds cleanup-during-heartbeat race test (route survives with active heartbeats)

All tests are additive (test files only, no source modifications) and written against the current codebase.

**Note:** This PR should be merged LAST as other PRs may change source file signatures.

Closes #10

## Test plan
- [x] `go test -v -race ./...` passes (all 4 packages)
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for route heartbeat behavior, DNS query handling, and certificate cache management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->