### PR TITLE
fix: improve uninstall error handling and messaging

### DIFF
--- a/internal/setup/uninstall_darwin.go
+++ b/internal/setup/uninstall_darwin.go
@@ -87,11 +87,15 @@ func Uninstall(supportDir, tld string, fromBrew bool) error {
 				if strings.HasPrefix(line, "SHA-1 hash:") {
 					sha := strings.TrimSpace(strings.TrimPrefix(line, "SHA-1 hash:"))
 					if sha != "" {
+						short := sha
+						if len(short) > 8 {
+							short = short[:8]
+						}
 						if err := exec.Command("security", "delete-certificate", "-Z", sha, keychainPath).Run(); err != nil {
-							errs = append(errs, fmt.Errorf("removing cert %s: %w", sha[:8], err))
-							fmt.Fprintf(os.Stderr, "  warning: could not remove certificate %s: %v\n", sha[:8], err)
+							errs = append(errs, fmt.Errorf("removing cert %s: %w", short, err))
+							fmt.Fprintf(os.Stderr, "  warning: could not remove certificate %s: %v\n", short, err)
 						} else {
-							fmt.Printf("  Removed certificate %s\n", sha[:8])
+							fmt.Printf("  Removed certificate %s\n", short)
 						}
 					}
 				}


### PR DESCRIPTION
## Summary
- Use `errors.Join` for proper error aggregation with `%w` wrapping instead of string concatenation (closes #97)
- Add `// SECURITY:` comment on `launchctl` exec explaining no-shell mitigation (closes #98)
- Print "not found (already removed)" for files that are already absent instead of misleading "removed" (closes #99)
- Distinguish `security find-certificate` exit code 44 (errSecItemNotFound) from real failures like permission denied (closes #100)

## Test plan
- [ ] `go test -v -race ./...` passes
- [ ] `go vet ./...` clean
- [ ] Manual verification: run `paw-proxy uninstall` when already uninstalled — should show "not found" messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error messages and handling during macOS uninstall process
  * Enhanced handling of already-removed components during uninstall
  * Refined error reporting for certificate removal and DNS resolver cleanup operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->