### PR TITLE
feat: enable HTTP/2 support via ServeTLS

### DIFF
--- a/integration-tests.sh
+++ b/integration-tests.sh
@@ -32,6 +32,20 @@ echo "[Test 5] HTTPS certificate..."
 echo | openssl s_client -connect integration-test.test:443 -servername integration-test.test 2>/dev/null | openssl x509 -noout -subject | grep -q "\\*.test"
 echo "  ✓ Wildcard certificate issued for *.test"
 
+# Test 5b: HTTP/2 negotiation
+# Certificate validity is already tested above; here we only check ALPN protocol.
+echo "[Test 5b] HTTP/2 negotiation..."
+HTTP2_PROTO=$(curl -k --resolve integration-test.test:443:127.0.0.1 \
+  -o /dev/null -w '%{http_version}' \
+  -s https://integration-test.test:443/ 2>/dev/null || true)
+
+if [ "$HTTP2_PROTO" = "2" ]; then
+  echo "  ✓ HTTP/2 negotiated"
+else
+  echo "  ✗ Expected HTTP/2 but got HTTP/$HTTP2_PROTO"
+  exit 1
+fi
+
 # Test 6: Heartbeat
 echo "[Test 6] Heartbeat..."
 curl -sf --unix-socket ~/Library/Application\ Support/paw-proxy/paw-proxy.sock \

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -194,7 +194,8 @@ func (d *Daemon) Run() error {
 	go func() {
 		defer wg.Done()
 		d.logger.Info("server started", "component", "https", "addr", httpsListener.Addr().String())
-		if err := httpsServer.Serve(httpsListener); err != nil && err != http.ErrServerClosed {
+		// ServeTLS wraps the plain listener with TLS and auto-configures HTTP/2
+		if err := httpsServer.ServeTLS(httpsListener, "", ""); err != nil && err != http.ErrServerClosed {
 			errCh <- fmt.Errorf("HTTPS server: %w", err)
 		}
 	}()
@@ -302,8 +303,10 @@ func (d *Daemon) createHTTPServer() (*http.Server, net.Listener, error) {
 	return server, listener, nil
 }
 
-// createHTTPSServer creates the HTTPS server and its TLS listener.
+// createHTTPSServer creates the HTTPS server and its listener.
 // The caller owns the lifecycle of the returned server.
+// Uses net.Listen + ServeTLS instead of tls.Listen + Serve to enable
+// Go's automatic HTTP/2 configuration via h2 ALPN negotiation.
 func (d *Daemon) createHTTPSServer() (*http.Server, net.Listener, error) {
 	// SECURITY: Bind to loopback only to prevent external access
 	addr := fmt.Sprintf("127.0.0.1:%d", d.config.HTTPSPort)
@@ -322,13 +325,15 @@ func (d *Daemon) createHTTPSServer() (*http.Server, net.Listener, error) {
 		},
 	}
 
-	listener, err := tls.Listen("tcp", addr, tlsConfig)
+	// Use plain TCP listener — ServeTLS wraps it with TLS and enables HTTP/2
+	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		return nil, nil, fmt.Errorf("listening on %s: %w", addr, err)
 	}
 
 	server := &http.Server{
 		Handler:     http.HandlerFunc(d.handleRequest),
+		TLSConfig:   tlsConfig,
 		IdleTimeout: 120 * time.Second,
 	}
 


### PR DESCRIPTION
## Summary
- Switch `createHTTPSServer()` from `tls.Listen` + `Serve` to `net.Listen` + `ServeTLS` to enable Go's automatic HTTP/2 configuration via h2 ALPN negotiation
- WebSocket clients naturally fall back to HTTP/1.1 via ALPN, no code changes needed in `proxy.go`
- Added integration test (Test 5b) verifying HTTP/2 negotiation with `curl -k`

Closes #20

## Test plan
- [x] `go test -race ./...` passes
- [x] `go vet ./...` clean
- [ ] Integration test verifies HTTP/2 negotiation (Test 5b: `curl -w '%{http_version}'`)
- [ ] Existing HTTPS/WebSocket tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added HTTP/2 negotiation verification test to ensure proper protocol support

* **Chores**
  * Enabled automatic HTTP/2 support for HTTPS connections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->