### PR TITLE
feat: add launchd socket activation

### DIFF
--- a/internal/launchd/launchd_darwin_cgo.go
+++ b/internal/launchd/launchd_darwin_cgo.go
@@ -1,0 +1,74 @@
+//go:build darwin && cgo
+
+// internal/launchd/launchd_darwin_cgo.go
+package launchd
+
+/*
+#include <launch.h>
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"unsafe"
+)
+
+// Error codes returned by launch_activate_socket as its return value
+// (not via errno). These match standard errno constants.
+const (
+	esrch  = 3 // not launched by launchd
+	enoent = 2 // socket name not found in plist
+)
+
+// ActivateSocket asks launchd for a pre-bound socket by name.
+// Returns (listener, true, nil) on success.
+// Returns (nil, false, nil) when not launched by launchd (ESRCH/ENOENT).
+// Returns (nil, false, err) on unexpected errors.
+func ActivateSocket(name string) (net.Listener, bool, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	var fds *C.int
+	var cnt C.size_t
+
+	// launch_activate_socket returns 0 on success, or an errno-style
+	// error code directly as its return value (not via errno).
+	rc := C.launch_activate_socket(cName, &fds, &cnt)
+	if rc != 0 {
+		// ESRCH: not launched by launchd
+		// ENOENT: socket name not found in plist
+		// Both mean "fall back to direct binding"
+		if rc == esrch || rc == enoent {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("launch_activate_socket(%q): error code %d", name, rc)
+	}
+	defer C.free(unsafe.Pointer(fds))
+
+	if cnt == 0 {
+		return nil, false, fmt.Errorf("launch_activate_socket(%q): returned 0 fds", name)
+	}
+
+	// Use the first file descriptor (plist declares one socket per name)
+	fdSlice := unsafe.Slice((*C.int)(fds), int(cnt))
+	fd := uintptr(fdSlice[0])
+
+	// Close any extra fds we won't use
+	for i := 1; i < int(cnt); i++ {
+		_ = os.NewFile(uintptr(fdSlice[i]), "").Close()
+	}
+
+	// Wrap fd as net.Listener. net.FileListener dups the fd,
+	// so we must close the original os.File to avoid leaking it.
+	f := os.NewFile(fd, name)
+	listener, err := net.FileListener(f)
+	f.Close()
+	if err != nil {
+		return nil, false, fmt.Errorf("net.FileListener for %q: %w", name, err)
+	}
+
+	return listener, true, nil
+}

--- a/internal/launchd/launchd_darwin_nocgo.go
+++ b/internal/launchd/launchd_darwin_nocgo.go
@@ -1,0 +1,12 @@
+//go:build darwin && !cgo
+
+// internal/launchd/launchd_darwin_nocgo.go
+package launchd
+
+import "net"
+
+// ActivateSocket is a stub for builds without cgo (e.g., cross-compilation).
+// Always returns (nil, false, nil) to trigger fallback to direct binding.
+func ActivateSocket(_ string) (net.Listener, bool, error) {
+	return nil, false, nil
+}

--- a/internal/launchd/launchd_other.go
+++ b/internal/launchd/launchd_other.go
@@ -1,0 +1,12 @@
+//go:build !darwin
+
+// internal/launchd/launchd_other.go
+package launchd
+
+import "net"
+
+// ActivateSocket is a stub for non-macOS platforms.
+// Always returns (nil, false, nil) to trigger fallback to direct binding.
+func ActivateSocket(_ string) (net.Listener, bool, error) {
+	return nil, false, nil
+}

--- a/internal/launchd/launchd_test.go
+++ b/internal/launchd/launchd_test.go
@@ -1,0 +1,35 @@
+package launchd
+
+import "testing"
+
+func TestActivateSocket_FallbackWhenNotLaunchdManaged(t *testing.T) {
+	// When not launched by launchd (or on non-macOS), ActivateSocket
+	// should return (nil, false, nil) to signal fallback to direct binding.
+	listener, activated, err := ActivateSocket("http")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if activated {
+		t.Fatal("expected activated=false when not launched by launchd")
+	}
+	if listener != nil {
+		listener.Close()
+		t.Fatal("expected nil listener when not launched by launchd")
+	}
+}
+
+func TestActivateSocket_UnknownSocketName(t *testing.T) {
+	// Even with a bogus socket name, the function should gracefully
+	// fall back rather than error (not launched by launchd).
+	listener, activated, err := ActivateSocket("nonexistent_socket_xyz")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if activated {
+		t.Fatal("expected activated=false for unknown socket name")
+	}
+	if listener != nil {
+		listener.Close()
+		t.Fatal("expected nil listener for unknown socket name")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `internal/launchd/` package that calls macOS `launch_activate_socket()` via cgo to receive pre-bound file descriptors from launchd
- Modify `createHTTPServer()` and `createHTTPSServer()` in the daemon to try socket activation first, falling back to direct `net.Listen()` binding
- Include build-tag stubs for non-cgo (`darwin && !cgo`) and non-macOS (`!darwin`) builds so CI works everywhere

Closes #13

## How it works

When the daemon is launched by launchd (via the LaunchAgent plist), `launch_activate_socket("http")` / `launch_activate_socket("https")` returns pre-bound file descriptors that launchd holds across restarts. This gives:

- **Zero bind conflicts** — launchd owns ports 80/443, no `EADDRINUSE`
- **Zero-downtime restarts** — launchd holds sockets while daemon restarts
- **Graceful fallback** — when running via `paw-proxy run` in foreground, `ESRCH` triggers direct binding

## CI compatibility

| Job | OS | CGO | File selected |
|-----|----|-----|---------------|
| test | ubuntu | n/a | `launchd_other.go` |
| lint | ubuntu | n/a | `launchd_other.go` |
| build | ubuntu, `GOOS=darwin` | disabled | `launchd_darwin_nocgo.go` |
| integration | macos-14 | enabled | `launchd_darwin_cgo.go` |

## Test plan

- [x] `go test -v -race ./...` — all pass
- [x] `go vet ./...` — clean
- [x] `go build ./cmd/paw-proxy && go build ./cmd/up` — compiles
- [ ] Manual: `paw-proxy run` in foreground — should log "using direct binding"
- [ ] Manual: `launchctl unload/load` the plist — should log "using launchd socket activation"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added macOS launchd socket activation support for HTTP and HTTPS servers, enabling better integration with the system service manager.

* **Improvements**
  * Implemented graceful fallback to direct port binding when socket activation is unavailable or not launched by launchd, with enhanced logging to indicate the active binding mode.

* **Tests**
  * Added tests for socket activation fallback behavior and unknown socket name handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->