### PR TITLE
fix: validate launchd socket fds before accept

### DIFF
--- a/internal/launchd/validate_test.go
+++ b/internal/launchd/validate_test.go
@@ -1,0 +1,97 @@
+//go:build darwin
+
+package launchd
+
+import (
+	"net"
+	"syscall"
+	"testing"
+)
+
+func TestCloseFD_ValidFD(t *testing.T) {
+	// Create a socket fd then close it via closeFD. Verify no panic.
+	fd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatalf("creating test socket: %v", err)
+	}
+	closeFD(fd)
+
+	// Verify the fd is closed by trying to use it — should fail.
+	_, err = syscall.GetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_TYPE)
+	if err == nil {
+		t.Error("expected error using closed fd, got nil")
+	}
+}
+
+func TestValidation_StreamSocketType(t *testing.T) {
+	// Create a TCP socket and verify SO_TYPE returns SOCK_STREAM.
+	fd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatalf("creating test socket: %v", err)
+	}
+	defer closeFD(fd)
+
+	sockType, err := syscall.GetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_TYPE)
+	if err != nil {
+		t.Fatalf("getsockopt SO_TYPE: %v", err)
+	}
+	if sockType != syscall.SOCK_STREAM {
+		t.Errorf("expected SOCK_STREAM (%d), got %d", syscall.SOCK_STREAM, sockType)
+	}
+}
+
+func TestValidation_ListenOnBoundSocket(t *testing.T) {
+	// Create a TCP socket, bind it, listen on it, then verify accept works.
+	fd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatalf("creating test socket: %v", err)
+	}
+	defer closeFD(fd)
+
+	// Bind to loopback on any port
+	sa := &syscall.SockaddrInet4{Port: 0, Addr: [4]byte{127, 0, 0, 1}}
+	if err := syscall.Bind(fd, sa); err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+
+	// Listen should succeed
+	if err := syscall.Listen(fd, syscall.SOMAXCONN); err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	// Calling listen again should also succeed (idempotent on BSD)
+	if err := syscall.Listen(fd, syscall.SOMAXCONN); err != nil {
+		t.Fatalf("second listen: %v", err)
+	}
+
+	// The socket should have a valid bound address with non-zero port
+	boundSA, err := syscall.Getsockname(fd)
+	if err != nil {
+		t.Fatalf("getsockname: %v", err)
+	}
+	inet4, ok := boundSA.(*syscall.SockaddrInet4)
+	if !ok {
+		t.Fatalf("expected SockaddrInet4, got %T", boundSA)
+	}
+	if inet4.Port == 0 {
+		t.Error("expected non-zero port after bind")
+	}
+}
+
+func TestValidation_ListenerAddressCheck(t *testing.T) {
+	// Create a proper listening socket via net.Listen, then verify
+	// the address check logic from ActivateSocket would pass.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	defer ln.Close()
+
+	tcpAddr, ok := ln.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("expected *net.TCPAddr, got %T", ln.Addr())
+	}
+	if tcpAddr.Port == 0 {
+		t.Error("listener should have a non-zero port")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the `accept: invalid argument` error when the daemon starts via LaunchAgent socket activation (#124). The root cause was two-fold:

1. **Plist config** (fixed in #128): Missing `SockType=stream` and `SockPassive=true` meant launchd might not call `listen()` on the socket
2. **No fd validation** (this PR): `ActivateSocket()` blindly passed launchd fds to `net.FileListener` without checking if they were valid listening TCP sockets

### Changes to `internal/launchd/launchd_darwin_cgo.go`:
- **SO_TYPE check**: Validates the fd is `SOCK_STREAM` (TCP), rejecting UDP or Unix sockets from a misconfigured plist
- **Defensive `listen()` call**: `syscall.Listen(fd, SOMAXCONN)` ensures the socket is in listening state. On BSD, calling `listen()` on an already-listening socket safely updates the backlog
- **Address validation**: After `net.FileListener`, checks that the bound port is non-zero — catches the `0.0.0.0:0` symptom
- **`closeFD` helper**: Extracts fd cleanup into a named function for clarity

Closes #124

## Test plan

- [ ] `go test -v -race ./...` passes (4 new tests in `internal/launchd/`)
- [ ] `go vet ./...` clean
- [ ] Manual: `sudo paw-proxy uninstall && sudo paw-proxy setup`
- [ ] Verify daemon logs show `using launchd socket activation` with valid addresses (not `0.0.0.0:0`)
- [ ] Verify `curl https://myapp.test` works after registering a route

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced socket validation and error handling for improved system reliability

* **Tests**
  * Added network socket behavior test coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->