### PR TITLE
chore: add .project.json for portfolio

### DIFF
--- a/.project.json
+++ b/.project.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://alexcatdad.github.io/schemas/project-meta.schema.json",
+  "what": "Zero-config HTTPS proxy for local macOS development.",
+  "why": "Built to remove HTTPS friction from OAuth and secure-cookie local workflows.",
+  "tags": ["go", "macos", "developer-tools", "networking"],
+  "featured": true,
+  "order": 10
+}


### PR DESCRIPTION
Adds `.project.json` metadata consumed by [alexcatdad.github.io](https://alexcatdad.github.io) snapshot generation.

Schema: [`project-meta.schema.json`](https://alexcatdad.github.io/schemas/project-meta.schema.json)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)