### PR TITLE
feat: auto-update homebrew-tap README on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,34 +269,34 @@ jobs:
         env:
           OWNER: ${{ github.repository_owner }}
         run: |
-          TABLE="| Formula | Version | Description |\n|---------|---------|-------------|"
+          TABLE=$'| Formula | Version | Description |\n|---------|---------|-------------|'
           for rb in Formula/*.rb; do
             name=$(basename "$rb" .rb)
             ver=$(grep -m1 'version "' "$rb" | sed 's/.*version "//;s/".*//')
             desc=$(grep -m1 'desc "' "$rb" | sed 's/.*desc "//;s/".*//')
-            TABLE="${TABLE}\n| [${name}](https://github.com/${OWNER}/${name}) | ${ver} | ${desc} |"
+            TABLE="${TABLE}"$'\n'"| [${name}](https://github.com/${OWNER}/${name}) | ${ver} | ${desc} |"
           done
           if [ -d Casks ]; then
             for rb in Casks/*.rb; do
               name=$(basename "$rb" .rb)
               ver=$(grep -m1 'version "' "$rb" | sed 's/.*version "//;s/".*//')
               desc=$(grep -m1 'desc "' "$rb" | sed 's/.*desc "//;s/".*//')
-              TABLE="${TABLE}\n| [${name}](https://github.com/${OWNER}/${name}) | ${ver} | ${desc} (cask) |"
+              TABLE="${TABLE}"$'\n'"| [${name}](https://github.com/${OWNER}/${name}) | ${ver} | ${desc} (cask) |"
             done
           fi
 
-          INSTALL="\`\`\`bash\n"
+          INSTALL=$'```bash\n'
           for rb in Formula/*.rb; do
             name=$(basename "$rb" .rb)
-            INSTALL="${INSTALL}brew install ${OWNER}/tap/${name}\n"
+            INSTALL="${INSTALL}brew install ${OWNER}/tap/${name}"$'\n'
           done
           if [ -d Casks ]; then
             for rb in Casks/*.rb; do
               name=$(basename "$rb" .rb)
-              INSTALL="${INSTALL}brew install --cask ${OWNER}/tap/${name}\n"
+              INSTALL="${INSTALL}brew install --cask ${OWNER}/tap/${name}"$'\n'
             done
           fi
-          INSTALL="${INSTALL}\`\`\`"
+          INSTALL="${INSTALL}"$'```\n'
 
           awk -v table="$TABLE" -v install="$INSTALL" '
             /<!-- BEGIN FORMULAE -->/ { print; printf "%s\n", table; skip=1; next }


### PR DESCRIPTION
## Summary

- Regenerate homebrew-tap README formula table and install block on each release
- Parses all `Formula/*.rb` files so the table stays current across all tools
- Matches the same step added to paw's release workflow

## Test plan

- [ ] Next release should update both `Formula/paw-proxy.rb` and `README.md` in homebrew-tap
- [ ] Verify table and install block reflect all current formulas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Workflow now regenerates README sections with formula listings and computed installation commands (including optional casks), injects the updated blocks into the README, and ensures README changes are staged and committed. The update runs on releases and after Homebrew formula updates to keep the README synchronized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->