### PR TITLE
docs: update installation to use homebrew tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,7 @@ up npm run dev
 ## Installation
 
 ```bash
-# Download latest release
-curl -L https://github.com/alexcatdad/paw-proxy/releases/latest/download/paw-proxy-darwin-universal -o /usr/local/bin/paw-proxy
-curl -L https://github.com/alexcatdad/paw-proxy/releases/latest/download/up-darwin-universal -o /usr/local/bin/up
-chmod +x /usr/local/bin/paw-proxy /usr/local/bin/up
+brew install alexcatdad/tap/paw-proxy
 
 # Run setup (creates CA, configures DNS, installs daemon)
 sudo paw-proxy setup


### PR DESCRIPTION
## Summary

- Replace manual curl/chmod installation with `brew install alexcatdad/tap/paw-proxy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified installation instructions: Installation now available via a single Homebrew command instead of manual download and setup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->