### PR TITLE
fix(ci): avoid false daemon liveness failure under sudo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,20 +78,22 @@ jobs:
           # Bootout any launchd-managed instance first to free the sockets.
           sudo launchctl bootout "gui/$(id -u)/dev.paw-proxy" 2>/dev/null || true
           sudo ./paw-proxy run &
-          DAEMON_PID=$!
-          echo "DAEMON_PID=$DAEMON_PID" >> "$GITHUB_ENV"
+          # `$!` is the transient sudo wrapper PID, not the daemon PID.
+          # Wait for socket readiness instead of checking process liveness.
+          SOCKET_READY=0
           for i in 1 2 3 4 5 6 7 8 9 10; do
             if [ -S "$HOME/Library/Application Support/paw-proxy/paw-proxy.sock" ]; then
               echo "Socket appeared after ${i}s"
+              SOCKET_READY=1
               break
-            fi
-            if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
-              echo "::error::Daemon process exited prematurely"
-              cat "$HOME/Library/Logs/paw-proxy.log" 2>/dev/null || true
-              exit 1
             fi
             sleep 1
           done
+          if [ "$SOCKET_READY" -ne 1 ]; then
+            echo "::error::Daemon socket did not appear within timeout"
+            cat "$HOME/Library/Logs/paw-proxy.log" 2>/dev/null || true
+            exit 1
+          fi
           sudo chown "$USER" "$HOME/Library/Application Support/paw-proxy/paw-proxy.sock"
           chmod 600 "$HOME/Library/Application Support/paw-proxy/paw-proxy.sock"
       - name: Wait for daemon


### PR DESCRIPTION
## Summary
- remove PID-based liveness check in CI `Start daemon` step
- wait for unix socket readiness with explicit timeout failure
- keep daemon log dump on timeout for debugging

## Why
The previous check used `DAEMON_PID=$!` after `sudo ./paw-proxy run &`, but `$!` is the transient sudo wrapper process on macOS runners. CI would fail with `Daemon process exited prematurely` even when the daemon had started correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI pipeline daemon startup verification by switching to socket-ready detection with enhanced timeout error handling for more reliable build validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->