### PR TITLE
style(dashboard): Terminal Noir UI redesign

### DIFF
--- a/internal/dashboard/static/index.html
+++ b/internal/dashboard/static/index.html
@@ -7,43 +7,63 @@
 <link rel="stylesheet" href="/style.css">
 </head>
 <body>
+<div class="noise"></div>
+
 <header>
   <div class="header-left">
+    <div class="logo-mark">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <circle cx="7" cy="6" r="2.5" fill="currentColor" opacity="0.8"/>
+        <circle cx="17" cy="6" r="2.5" fill="currentColor" opacity="0.8"/>
+        <circle cx="4" cy="13" r="2" fill="currentColor" opacity="0.6"/>
+        <circle cx="20" cy="13" r="2" fill="currentColor" opacity="0.6"/>
+        <ellipse cx="12" cy="17" rx="5" ry="4" fill="currentColor"/>
+      </svg>
+    </div>
     <h1>paw-proxy</h1>
     <span id="version" class="badge"></span>
   </div>
   <div class="header-right">
-    <span id="uptime"></span>
-    <span id="sse-dot" class="dot dot-off" title="SSE disconnected"></span>
+    <span id="uptime" class="uptime-label"></span>
+    <span class="sse-indicator">
+      <span id="sse-dot" class="dot dot-off" title="SSE disconnected"></span>
+      <span class="sse-label">live</span>
+    </span>
   </div>
 </header>
 
-<section id="routes-section">
-  <h2>Active Routes</h2>
-  <table id="routes-table">
-    <thead>
-      <tr>
-        <th>Route</th>
-        <th>Upstream</th>
-        <th>Dir</th>
-        <th>Uptime</th>
-        <th>Reqs</th>
-        <th>Avg</th>
-        <th>Errors</th>
-      </tr>
-    </thead>
-    <tbody id="routes-body"></tbody>
-  </table>
-  <p id="no-routes" class="muted">No active routes. Start a dev server with <code>up &lt;command&gt;</code></p>
+<section id="routes-section" class="card">
+  <div class="section-header">
+    <h2>Active Routes</h2>
+  </div>
+  <div class="table-wrap">
+    <table id="routes-table">
+      <thead>
+        <tr>
+          <th>Route</th>
+          <th>Upstream</th>
+          <th>Dir</th>
+          <th>Uptime</th>
+          <th class="num">Reqs</th>
+          <th class="num">Avg</th>
+          <th class="num">Errors</th>
+        </tr>
+      </thead>
+      <tbody id="routes-body"></tbody>
+    </table>
+  </div>
+  <p id="no-routes" class="empty-state">No active routes &mdash; start a dev server with <code>up &lt;command&gt;</code></p>
 </section>
 
-<section id="feed-section">
+<section id="feed-section" class="card">
   <div class="feed-header">
     <h2>Request Feed</h2>
     <div class="feed-controls">
       <span id="filter-label" hidden>
-        Filtering: <strong id="filter-name"></strong>
-        <button id="clear-filter" class="btn-small">&times;</button>
+        <span class="filter-badge">
+          <strong id="filter-name"></strong>
+          <button id="clear-filter" class="btn-icon" aria-label="Clear filter">&times;</button>
+        </span>
       </span>
       <button id="pause-btn" class="btn-small">Pause</button>
     </div>

--- a/internal/dashboard/static/style.css
+++ b/internal/dashboard/static/style.css
@@ -1,170 +1,458 @@
+/* ── paw-proxy dashboard ── terminal noir theme ── */
+
 :root {
-  --bg: #1a1a2e;
-  --bg-surface: #16213e;
-  --bg-hover: #1f2b47;
-  --text: #e0e0e0;
-  --text-muted: #8892a4;
-  --border: #2a2a4a;
-  --accent: #4fc3f7;
-  --green: #66bb6a;
-  --blue: #42a5f5;
-  --amber: #ffa726;
-  --red: #ef5350;
-  --mono: "SF Mono", "Cascadia Code", "Fira Code", Consolas, monospace;
+  --bg:          #0c0c0f;
+  --bg-surface:  #141419;
+  --bg-elevated: #1a1a22;
+  --bg-hover:    #22222e;
+  --text:        #c8c8d0;
+  --text-bright: #eaeaf0;
+  --text-muted:  #5e5e72;
+  --border:      #1e1e2a;
+  --border-subtle: #16161f;
+  --accent:      #e8a838;
+  --accent-dim:  #b07820;
+  --accent-glow: rgba(232, 168, 56, 0.15);
+  --green:       #5cb85c;
+  --green-dim:   rgba(92, 184, 92, 0.12);
+  --blue:        #5b9bd5;
+  --amber:       #d4943a;
+  --red:         #d45050;
+  --red-dim:     rgba(212, 80, 80, 0.12);
+  --mono:        "SF Mono", "Berkeley Mono", "JetBrains Mono", "Fira Code", Menlo, Monaco, Consolas, monospace;
+  --sans:        "SF Pro Display", "SF Pro", system-ui, -apple-system, "Helvetica Neue", sans-serif;
+  --radius:      8px;
+  --radius-sm:   4px;
 }
 
 @media (prefers-color-scheme: light) {
   :root {
-    --bg: #f5f5f5;
-    --bg-surface: #ffffff;
-    --bg-hover: #eef2f7;
-    --text: #1a1a2e;
-    --text-muted: #6b7280;
-    --border: #d1d5db;
-    --accent: #0288d1;
-    --green: #2e7d32;
-    --blue: #1565c0;
-    --amber: #e65100;
-    --red: #c62828;
+    --bg:          #f4f2ee;
+    --bg-surface:  #ffffff;
+    --bg-elevated: #faf9f7;
+    --bg-hover:    #f0ede8;
+    --text:        #2c2c34;
+    --text-bright: #1a1a1f;
+    --text-muted:  #8a8a96;
+    --border:      #e2e0da;
+    --border-subtle: #ece9e3;
+    --accent:      #c07b18;
+    --accent-dim:  #a06510;
+    --accent-glow: rgba(192, 123, 24, 0.08);
+    --green:       #3a8a3a;
+    --green-dim:   rgba(58, 138, 58, 0.08);
+    --blue:        #2868a8;
+    --amber:       #a06a18;
+    --red:         #b83030;
+    --red-dim:     rgba(184, 48, 48, 0.08);
   }
+
+  .noise { display: none; }
 }
 
-* { margin: 0; padding: 0; box-sizing: border-box; }
+/* ── reset ── */
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
 
+/* ── noise overlay (dark only) ── */
+.noise {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9999;
+  opacity: 0.025;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-repeat: repeat;
+  background-size: 256px 256px;
+}
+
+/* ── body ── */
 body {
-  font-family: -apple-system, system-ui, "Segoe UI", sans-serif;
+  font-family: var(--sans);
   background: var(--bg);
   color: var(--text);
-  max-width: 1200px;
+  max-width: 1080px;
   margin: 0 auto;
-  padding: 16px 24px;
+  padding: 24px 32px 48px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
+/* ── page load animation ── */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+header, .card {
+  animation: fadeUp 0.4s ease-out both;
+}
+
+.card:nth-child(2) { animation-delay: 0.08s; }
+.card:nth-child(3) { animation-delay: 0.16s; }
+
+/* ── header ── */
 header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 0;
+  padding: 0 0 20px;
+  margin-bottom: 28px;
   border-bottom: 1px solid var(--border);
-  margin-bottom: 24px;
 }
 
-.header-left { display: flex; align-items: center; gap: 12px; }
-.header-right { display: flex; align-items: center; gap: 16px; color: var(--text-muted); font-size: 14px; }
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
 
-h1 { font-size: 20px; font-weight: 600; }
-h2 { font-size: 16px; font-weight: 600; margin-bottom: 12px; }
+.logo-mark {
+  color: var(--accent);
+  display: flex;
+  align-items: center;
+  filter: drop-shadow(0 0 6px var(--accent-glow));
+}
+
+h1 {
+  font-family: var(--mono);
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--text-bright);
+}
 
 .badge {
-  font-size: 11px;
-  padding: 2px 8px;
-  border-radius: 10px;
-  background: var(--bg-hover);
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 500;
+  padding: 2px 7px;
+  border-radius: 3px;
+  background: var(--bg-elevated);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  letter-spacing: 0.02em;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.uptime-label {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text-muted);
+  letter-spacing: 0.01em;
+}
+
+.sse-indicator {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.sse-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
   color: var(--text-muted);
 }
 
+/* ── SSE dot with pulse ── */
 .dot {
-  width: 8px; height: 8px;
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
   display: inline-block;
+  flex-shrink: 0;
 }
-.dot-on { background: var(--green); }
-.dot-off { background: var(--red); }
 
-section { margin-bottom: 32px; }
+.dot-on {
+  background: var(--green);
+  box-shadow: 0 0 6px var(--green), 0 0 12px rgba(92, 184, 92, 0.3);
+  animation: pulse 2s ease-in-out infinite;
+}
+
+.dot-off {
+  background: var(--red);
+  box-shadow: 0 0 4px rgba(212, 80, 80, 0.3);
+  animation: none;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; box-shadow: 0 0 6px var(--green), 0 0 12px rgba(92, 184, 92, 0.3); }
+  50%      { opacity: 0.6; box-shadow: 0 0 3px var(--green), 0 0 6px rgba(92, 184, 92, 0.15); }
+}
+
+/* ── cards ── */
+.card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+  margin-bottom: 20px;
+}
+
+.section-header {
+  margin-bottom: 16px;
+}
+
+h2 {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+}
+
+/* ── table ── */
+.table-wrap {
+  overflow-x: auto;
+  margin: 0 -20px;
+  padding: 0 20px;
+}
 
 table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 13px;
+  font-family: var(--mono);
+  font-size: 12px;
 }
 
 th {
   text-align: left;
-  padding: 8px 12px;
-  border-bottom: 2px solid var(--border);
+  padding: 0 12px 10px;
   color: var(--text-muted);
   font-weight: 500;
-  font-size: 12px;
+  font-size: 10px;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-td {
-  padding: 8px 12px;
+  letter-spacing: 0.08em;
   border-bottom: 1px solid var(--border);
 }
 
-tr:hover td { background: var(--bg-hover); }
+th.num { text-align: right; }
 
-tr.clickable { cursor: pointer; }
+td {
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text);
+  vertical-align: middle;
+}
+
+tr.clickable {
+  cursor: pointer;
+  transition: background 0.12s ease;
+}
+
+tr.clickable:hover td {
+  background: var(--bg-hover);
+}
+
+tr.clickable:active td {
+  background: var(--accent-glow);
+}
 
 td a {
   color: var(--accent);
   text-decoration: none;
+  font-weight: 500;
 }
-td a:hover { text-decoration: underline; }
 
-.muted { color: var(--text-muted); font-size: 14px; }
+td a:hover {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+td.num { text-align: right; font-variant-numeric: tabular-nums; }
+
+.empty-state {
+  font-size: 13px;
+  color: var(--text-muted);
+  padding: 24px 0 4px;
+  text-align: center;
+}
 
 code {
   font-family: var(--mono);
-  background: var(--bg-hover);
+  font-size: 11px;
+  background: var(--bg-elevated);
   padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  color: var(--accent);
 }
 
+.muted { color: var(--text-muted); font-size: 13px; }
+
+/* ── feed ── */
 .feed-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 12px;
+  margin-bottom: 14px;
 }
 
-.feed-controls { display: flex; align-items: center; gap: 12px; font-size: 13px; }
+.feed-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+}
+
+.filter-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--mono);
+  font-size: 11px;
+  background: var(--accent-glow);
+  border: 1px solid var(--accent-dim);
+  color: var(--accent);
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+}
+
+.btn-icon {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 0 2px;
+  opacity: 0.7;
+}
+
+.btn-icon:hover { opacity: 1; }
 
 .btn-small {
-  font-size: 12px;
-  padding: 4px 10px;
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 5px 12px;
   border: 1px solid var(--border);
-  border-radius: 4px;
-  background: var(--bg-surface);
-  color: var(--text);
+  border-radius: var(--radius-sm);
+  background: var(--bg-elevated);
+  color: var(--text-muted);
   cursor: pointer;
+  transition: all 0.12s ease;
 }
-.btn-small:hover { background: var(--bg-hover); }
+
+.btn-small:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+  border-color: var(--text-muted);
+}
 
 #feed-list {
   font-family: var(--mono);
-  font-size: 12px;
-  line-height: 1.6;
-  max-height: 500px;
+  font-size: 11px;
+  line-height: 1.7;
+  max-height: 520px;
   overflow-y: auto;
-  background: var(--bg-surface);
+  background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 8px;
+  border-radius: var(--radius-sm);
+  padding: 6px;
+}
+
+/* ── custom scrollbar ── */
+#feed-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+#feed-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+#feed-list::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
+}
+
+#feed-list::-webkit-scrollbar-thumb:hover {
+  background: var(--text-muted);
+}
+
+/* ── feed entries ── */
+@keyframes slideIn {
+  from { opacity: 0; transform: translateX(-6px); }
+  to   { opacity: 1; transform: translateX(0); }
 }
 
 .feed-entry {
   display: flex;
-  gap: 12px;
-  padding: 2px 4px;
-  border-radius: 3px;
+  gap: 8px;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  animation: slideIn 0.15s ease-out both;
+  font-variant-numeric: tabular-nums;
 }
-.feed-entry:hover { background: var(--bg-hover); }
 
-.feed-time { color: var(--text-muted); min-width: 70px; }
-.feed-method { min-width: 50px; font-weight: 600; }
-.feed-host { color: var(--accent); min-width: 140px; }
-.feed-path { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.feed-status { min-width: 36px; text-align: right; font-weight: 600; }
-.feed-latency { min-width: 50px; text-align: right; color: var(--text-muted); }
+.feed-entry:hover { background: var(--bg-elevated); }
 
+.feed-time {
+  color: var(--text-muted);
+  min-width: 68px;
+  font-size: 10px;
+  opacity: 0.7;
+}
+
+.feed-method {
+  min-width: 42px;
+  font-weight: 600;
+  color: var(--text-bright);
+}
+
+.feed-host {
+  color: var(--accent);
+  min-width: 130px;
+}
+
+.feed-path {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text);
+}
+
+.feed-status {
+  min-width: 32px;
+  text-align: right;
+  font-weight: 700;
+}
+
+.feed-latency {
+  min-width: 48px;
+  text-align: right;
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+/* ── status colors ── */
 .status-2xx { color: var(--green); }
 .status-3xx { color: var(--blue); }
 .status-4xx { color: var(--amber); }
 .status-5xx { color: var(--red); }
 
-.errors-nonzero { color: var(--red); font-weight: 600; }
+.errors-nonzero {
+  color: var(--red);
+  font-weight: 700;
+  background: var(--red-dim);
+  border-radius: var(--radius-sm);
+  padding: 1px 5px;
+}
+
+/* ── selection ── */
+::selection {
+  background: var(--accent);
+  color: var(--bg);
+}


### PR DESCRIPTION
## Summary
- Redesign dashboard HTML/CSS with a "Terminal Noir" aesthetic using the frontend-design skill
- Deep ink-black palette (`#0c0c0f`) with warm amber accent (`#e8a838`), SVG paw print logo, noise texture overlay
- Card-based layout, refined monospace typography (SF Mono / Berkeley Mono / JetBrains Mono stack)
- Light-mode support via `prefers-color-scheme` with warm paper tones
- Pulse animation on SSE dot, fade-up on cards, slide-in on feed entries, custom scrollbar styling
- All element IDs preserved — no JS changes needed, all 14 dashboard tests pass

## Test plan
- [x] `go test -v -race ./internal/dashboard/...` — 14/14 pass
- [ ] Visual check: open `https://_paw.test` with daemon running, verify dark theme renders correctly
- [ ] Visual check: toggle system to light mode, verify light theme renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SSE live status indicator in header
  * Introduced filter management controls with clear button in Request Feed
  * Implemented card-based layout for routes section

* **Style**
  * Added dark mode support with light mode override
  * Updated color palette and visual styling
  * Enhanced typography, spacing, and page animations
  * Improved status color coding and visual hierarchy throughout dashboard

<!-- end of auto-generated comment: release notes by coderabbit.ai -->