### PR TITLE
docs: add dashboard feature to README and GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ up npm run dev
 - **WebSocket support** - Hot reload works out of the box
 - **Smart naming** - Uses package.json name or directory name
 - **Conflict resolution** - Automatic fallback when a domain is already in use (great for git worktrees)
+- **Live dashboard** - Real-time request feed and route status at `https://_paw.test`
 
 ## Installation
 
@@ -59,6 +60,13 @@ paw-proxy status
 ```
 
 Your app is now available at `https://<name>.test`
+
+### Dashboard
+
+Visit `https://_paw.test` to see a live dashboard with:
+- Active routes and their uptime, request counts, and average latency
+- Real-time request feed via Server-Sent Events
+- Filter requests by route (click any route row)
 
 ### Git Worktrees
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -413,6 +413,11 @@
                     <p style="color: var(--text-secondary)">Automatic fallback when domains collide — run branches side by side</p>
                 </div>
                 <div class="clay-sm feature-card p-6">
+                    <div class="text-3xl mb-4">📊</div>
+                    <h3 class="text-lg font-bold mb-2" style="color: var(--text-primary)">Live Dashboard</h3>
+                    <p style="color: var(--text-secondary)">Real-time request feed and route stats at <code class="font-mono text-sm px-1.5 py-0.5 rounded" style="background: var(--bg-inset)">_paw.test</code></p>
+                </div>
+                <div class="clay-sm feature-card p-6">
                     <div class="text-3xl mb-4">🛡️</div>
                     <h3 class="text-lg font-bold mb-2" style="color: var(--text-primary)">Security First</h3>
                     <p style="color: var(--text-secondary)">TLS 1.2+, localhost-only binding</p>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -14,6 +14,7 @@ Key features:
 - LaunchAgent integration for automatic daemon start on macOS
 - Smart naming from package.json or directory name
 - Auto-restart on crash with `--restart` flag
+- Live web dashboard at `https://_paw.test` with real-time request feed and route stats
 
 ## Installation
 
@@ -239,6 +240,10 @@ internal/
 ├── api/        # Unix socket API and route registry
 │   ├── server.go     # HTTP handlers, input validation, rate limiting
 │   └── routes.go     # RouteRegistry with RWMutex, CRUD, cleanup
+├── dashboard/  # Live web dashboard
+│   ├── dashboard.go  # HTTP handlers, SSE streaming, embedded static files
+│   ├── metrics.go    # Ring buffer, route stats aggregation, SSE fan-out
+│   └── static/       # Embedded HTML, CSS, JS (Terminal Noir theme)
 ├── daemon/     # Main daemon orchestrator
 │   └── daemon.go     # Launches goroutines, TLS config, graceful shutdown
 ├── dns/        # DNS server for .test TLD
@@ -277,6 +282,30 @@ cmd/
 **TLS Configuration:** TLS 1.2 minimum. Cipher suites: ECDHE with AES-GCM and ChaCha20-Poly1305.
 
 **Network Binding:** HTTP and HTTPS servers bind to `127.0.0.1` (loopback only).
+
+## Dashboard
+
+Visit `https://_paw.test` while the daemon is running to access the live dashboard.
+
+### Features
+
+- **Active Routes table:** Shows each route's name, upstream, working directory, uptime, request count, average latency, and error count
+- **Real-time Request Feed:** SSE-powered live stream of all proxied requests with method, host, path, status code, and latency
+- **Route filtering:** Click any route row to filter the feed to that route's requests
+- **Pause/Resume:** Pause the live feed to inspect entries
+
+### Dashboard API
+
+The dashboard is served by the daemon when a request arrives for `_paw.test`. It exposes these endpoints:
+
+- `GET /` — Dashboard HTML (embedded static files)
+- `GET /api/routes` — JSON array of route stats (name, upstream, dir, uptime, requests, avgMs, errors)
+- `GET /api/stats` — JSON object with version and uptime
+- `GET /events` — SSE stream of new requests (JSON-encoded RequestEntry per event)
+
+### Architecture
+
+The dashboard uses a ring buffer (`Metrics`) to store the last 1000 requests. SSE subscribers receive new entries via non-blocking channel fan-out. Static files (HTML, CSS, JS) are embedded in the binary via `//go:embed`. The `_paw.test` hostname is intercepted in `daemon.handleRequest()` before metrics recording to prevent feedback loops.
 
 ## Unix Socket API
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -16,6 +16,7 @@ Two binaries: `paw-proxy` (daemon and management CLI) and `up` (dev server wrapp
 - [Quick start and examples](https://github.com/alexcatdad/paw-proxy#usage): `up bun dev`, `up -n myapp npm run dev`
 - [Environment variables](https://github.com/alexcatdad/paw-proxy#up): PORT, APP_DOMAIN, APP_URL, HTTPS, NODE_EXTRA_CA_CERTS
 - [Command reference](https://github.com/alexcatdad/paw-proxy#commands): setup, uninstall, status, run, logs, doctor, version
+- [Live dashboard](https://github.com/alexcatdad/paw-proxy#dashboard): Real-time request feed and route stats at `https://_paw.test`
 
 ### CLI Quick Reference
 
@@ -45,6 +46,7 @@ Two binaries: `paw-proxy` (daemon and management CLI) and `up` (dev server wrapp
 
 ### Key Source Files
 
+- [dashboard.go](https://github.com/alexcatdad/paw-proxy/blob/main/internal/dashboard/dashboard.go): Web dashboard HTTP handlers, SSE streaming, embedded static files
 - [daemon.go](https://github.com/alexcatdad/paw-proxy/blob/main/internal/daemon/daemon.go): Main daemon lifecycle (DNS, HTTP, HTTPS, cleanup goroutines)
 - [routes.go](https://github.com/alexcatdad/paw-proxy/blob/main/internal/api/routes.go): Route registry with RWMutex, heartbeat timeout
 - [server.go](https://github.com/alexcatdad/paw-proxy/blob/main/internal/api/server.go): Unix socket API, input validation (SSRF prevention)


### PR DESCRIPTION
## Summary
- Add "Live Dashboard" to README features list and new Dashboard usage section
- Add dashboard feature card to GitHub Pages landing page (`docs/index.html`)
- Add dashboard references to `llms.txt` (key source files section)
- Add full dashboard section to `llms-full.txt` (API, architecture, SSE streaming)

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify GitHub Pages landing page shows new dashboard feature card
- [ ] Verify `llms.txt` and `llms-full.txt` include dashboard content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live Dashboard: Real-time request feed, route filtering, and live uptime/latency metrics now available.

* **Documentation**
  * Updated documentation with Live Dashboard feature details and usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->