### PR TITLE
feat: add OS-level desktop notifications to up command

### DIFF
--- a/cmd/up/compose.go
+++ b/cmd/up/compose.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/alexcatdad/paw-proxy/internal/notification"
 )
 
 // composeDetection holds the result of scanning args for Docker Compose mode.
@@ -294,6 +296,7 @@ func runDockerComposeMode(client *http.Client, dc composeDetection, args []strin
 		fmt.Printf("   https://%s.test\n", r.routeName)
 	}
 	fmt.Println("------------------------------------------------")
+	notification.Notify("paw-proxy", fmt.Sprintf("%d services are live", len(routes)))
 
 	// 5. Start heartbeat
 	ctx, cancel := context.WithCancel(context.Background())
@@ -302,6 +305,7 @@ func runDockerComposeMode(client *http.Client, dc composeDetection, args []strin
 	// 6. Cleanup function
 	cleanup := func() {
 		fmt.Printf("\nRemoving %d route mappings...\n", len(routes))
+		notification.Notify("paw-proxy", fmt.Sprintf("Removing %d route mappings", len(routes)))
 		deregisterComposeRoutes(client, routes)
 	}
 

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/alexcatdad/paw-proxy/internal/help"
+	"github.com/alexcatdad/paw-proxy/internal/notification"
 	"github.com/alexcatdad/paw-proxy/internal/paths"
 )
 
@@ -119,6 +120,7 @@ func main() {
 	// Setup cleanup (deregisters route from daemon)
 	cleanup := func() {
 		fmt.Printf("\n🛑 Removing mapping for %s.test...\n", name)
+		notification.Notify("paw-proxy", fmt.Sprintf("Removing mapping for %s.test", name))
 		if err := deregisterRoute(client, name); err != nil {
 			log.Printf("warning: cleanup deregistration failed: %v", err)
 		}
@@ -165,6 +167,7 @@ func main() {
 		fmt.Printf("🔗 Mapping https://%s.test -> localhost:%d...\n", name, port)
 		if exitCode == 0 {
 			fmt.Printf("🚀 Project is live at: https://%s.test\n", name)
+			notification.Notify("paw-proxy", fmt.Sprintf("Project is live at: https://%s.test", name))
 		} else {
 			fmt.Printf("🔄 Restarting (previous exit code: %d)...\n", exitCode)
 		}

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -1,0 +1,14 @@
+package notification
+
+import (
+	"os/exec"
+)
+
+// commandRunner is used to execute shell commands.
+// It can be replaced in tests to verify command arguments.
+var commandRunner func(name string, arg ...string) *exec.Cmd = exec.Command
+
+// Notify sends a desktop notification.
+func Notify(title, message string) error {
+	return notify(title, message)
+}

--- a/internal/notification/notification_darwin.go
+++ b/internal/notification/notification_darwin.go
@@ -1,0 +1,18 @@
+//go:build darwin
+
+package notification
+
+import (
+	"fmt"
+	"strings"
+)
+
+func notify(title, message string) error {
+	// Simple osascript implementation
+	// We escape double quotes to avoid script errors
+	escapedMessage := strings.ReplaceAll(message, "\"", "\\\"")
+	escapedTitle := strings.ReplaceAll(title, "\"", "\\\"")
+
+	script := fmt.Sprintf("display notification %q with title %q sound name %q", escapedMessage, escapedTitle, "Glass")
+	return commandRunner("osascript", "-e", script).Run()
+}

--- a/internal/notification/notification_linux.go
+++ b/internal/notification/notification_linux.go
@@ -1,0 +1,8 @@
+//go:build linux
+
+package notification
+
+func notify(title, message string) error {
+	// Simple notify-send implementation
+	return commandRunner("notify-send", title, message).Run()
+}

--- a/internal/notification/notification_other.go
+++ b/internal/notification/notification_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !linux
+
+package notification
+
+func notify(title, message string) error {
+	return nil
+}

--- a/internal/notification/notification_test.go
+++ b/internal/notification/notification_test.go
@@ -1,0 +1,55 @@
+package notification
+
+import (
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestNotify(t *testing.T) {
+	var capturedCmd string
+	var capturedArgs []string
+
+	// Mock command runner
+	commandRunner = func(name string, arg ...string) *exec.Cmd {
+		capturedCmd = name
+		capturedArgs = arg
+		// Return a command that does nothing but exists
+		return exec.Command("true")
+	}
+
+	title := "test-title"
+	message := "test-message"
+	err := Notify(title, message)
+
+	if err != nil {
+		t.Fatalf("Notify failed: %v", err)
+	}
+
+	switch runtime.GOOS {
+	case "darwin":
+		if capturedCmd != "osascript" {
+			t.Errorf("Expected command 'osascript', got %q", capturedCmd)
+		}
+		if len(capturedArgs) != 2 || capturedArgs[0] != "-e" {
+			t.Errorf("Unexpected args: %v", capturedArgs)
+		}
+		expectedScriptPart := "display notification \"test-message\" with title \"test-title\""
+		if !strings.Contains(capturedArgs[1], expectedScriptPart) {
+			t.Errorf("Script doesn't contain expected part: %q", capturedArgs[1])
+		}
+	case "linux":
+		if capturedCmd != "notify-send" {
+			t.Errorf("Expected command 'notify-send', got %q", capturedCmd)
+		}
+		if len(capturedArgs) != 2 || capturedArgs[0] != title || capturedArgs[1] != message {
+			t.Errorf("Unexpected args: %v", capturedArgs)
+		}
+	default:
+		// Other platforms should be no-ops and not call commandRunner
+		if capturedCmd != "" {
+			t.Errorf("Expected no command for %s, got %q", runtime.GOOS, capturedCmd)
+		}
+	}
+}


### PR DESCRIPTION
This PR introduces native desktop notifications for the `up` command on macOS and Linux.

### Key Changes:
- **New `internal/notification` Package**: A cross-platform notification utility.
  - **macOS**: Uses `osascript` for native notifications with sound.
  - **Linux**: Uses `notify-send`.
  - **Others**: Graceful no-op fallback.
- **Single-app Mode**: Notifications on project startup and shutdown.
- **Docker Compose Mode**: Summary notifications when services go live or are removed.
- **Testing**: Added unit tests with a mock command runner to verify notification logic without side effects.

### Motivation:
Improves developer experience by providing immediate feedback when a project is live and when its proxy routes are cleaned up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced desktop notifications that alert users when services are live and during cleanup operations, providing real-time visibility into application lifecycle events across all supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->