### PR TITLE
fix: bump Go to 1.26.1 to resolve GO-2026-4601

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24.13'
-      - uses: golangci/golangci-lint-action@v4
+          go-version: '1.26.1'
+      - uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.11.3
 
   test:
     runs-on: ubuntu-latest
@@ -29,19 +31,16 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24.13'
+          go-version: '1.26.1'
       - run: go test -v -race ./...
 
   vulncheck:
     runs-on: ubuntu-latest
-    # Advisory only — Go stdlib vulns (GO-2026-4601, GO-2026-4602) require
-    # a Go release newer than 1.24.x. Remove continue-on-error once Go is bumped.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24.13'
+          go-version: '1.26.1'
       - run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
 
   build:
@@ -50,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24.13'
+          go-version: '1.26.1'
       - name: Build binaries
         run: |
           LDFLAGS="-X main.version=${GITHUB_REF_NAME:-dev} -X github.com/alexcatdad/paw-proxy/internal/api.Version=${GITHUB_REF_NAME:-dev}"
@@ -72,7 +71,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24.13'
+          go-version: '1.26.1'
       - name: Build
         run: |
           go build -o paw-proxy ./cmd/paw-proxy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/setup-go@v5
         if: steps.version.outputs.skip != 'true'
         with:
-          go-version: '1.24.13'
+          go-version: '1.26.1'
 
       - name: Run tests
         if: steps.version.outputs.skip != 'true'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,9 @@
+version: "2"
+
 linters:
-  disable:
-    - errcheck  # Too strict for simple CLI tools
+  default: none
   enable:
+    - govet
     - staticcheck
     - unused
     - ineffassign
-
-linters-settings:
-  govet:
-    disable:
-      - fieldalignment
-      - shadow

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alexcatdad/paw-proxy
 
-go 1.24.0
+go 1.26.1
 
 require github.com/miekg/dns v1.1.72
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -166,14 +166,14 @@ type idleTimeoutConn struct {
 }
 
 func (c *idleTimeoutConn) Read(b []byte) (int, error) {
-	if err := c.Conn.SetDeadline(time.Now().Add(c.timeout)); err != nil {
+	if err := c.SetDeadline(time.Now().Add(c.timeout)); err != nil {
 		return 0, fmt.Errorf("set read deadline: %w", err)
 	}
 	return c.Conn.Read(b)
 }
 
 func (c *idleTimeoutConn) Write(b []byte) (int, error) {
-	if err := c.Conn.SetDeadline(time.Now().Add(c.timeout)); err != nil {
+	if err := c.SetDeadline(time.Now().Add(c.timeout)); err != nil {
 		return 0, fmt.Errorf("set write deadline: %w", err)
 	}
 	return c.Conn.Write(b)


### PR DESCRIPTION
## Summary

- Bump Go from 1.24.13 to 1.26.1 across go.mod, ci.yml, and release.yml
- Resolves GO-2026-4601 (incorrect parsing of IPv6 host literals in net/url)
- Remove `continue-on-error: true` from vulncheck job — no longer needed

## Test plan

- [ ] `go test -race ./...` passes locally
- [ ] `govulncheck ./...` reports no vulnerabilities
- [ ] CI vulncheck job passes (no longer advisory)
- [ ] Build succeeds for all targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Go toolchain version across CI/CD workflows and project configuration
  * Enhanced vulnerability check workflow to enforce stricter error handling instead of continuing on failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->